### PR TITLE
Fix copyFileContents remaining byte calculation

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -314,7 +314,7 @@ func copyFileContents(size int64, src, dst *os.File, cb copyCallback) error {
 	bytesLeft := size
 	for bytesLeft > 0 {
 		nextBlock := blockSize
-		if nextBlock < bytesLeft {
+		if nextBlock > bytesLeft {
 			nextBlock = bytesLeft
 		}
 		n, err := io.CopyN(dst, src, nextBlock)


### PR DESCRIPTION
## Summary
- fix copyFileContents to limit copy size by remaining bytes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8b62716d48324aca275d311d6fdb9