### PR TITLE
refactor: centralize rclone path detection

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -119,7 +118,7 @@ func rootCommand(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		os.Exit(1)
 	}
-	if !isRclonePath(pullDir) {
+	if !util.IsRclonePath(pullDir) {
 		stat, err := os.Stat(pullDir)
 		if err != nil || !stat.IsDir() {
 			os.Stderr.WriteString(fmt.Sprintf("%q does not exist or is not a directory", pullDir))
@@ -136,7 +135,7 @@ func rootCommand(cmd *cobra.Command, args []string) {
 	if push == "" {
 		push = pullDir
 	}
-	if !isRclonePath(push) {
+	if !util.IsRclonePath(push) {
 		stat, err := os.Stat(push)
 		if err != nil || !stat.IsDir() {
 			os.Stderr.WriteString(fmt.Sprintf("%q does not exist or is not a directory", push))
@@ -163,15 +162,6 @@ func rootCommand(cmd *cobra.Command, args []string) {
 	}
 
 	service.Serve(pullDir, push, pullMain, pushMain, os.Stdin, os.Stdout, os.Stderr)
-}
-
-func isRclonePath(path string) bool {
-	if runtime.GOOS == "windows" {
-		if len(path) >= 2 && path[1] == ':' {
-			return false
-		}
-	}
-	return strings.Contains(path, ":")
 }
 
 func getGitConfig(key string) string {

--- a/service/service.go
+++ b/service/service.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/pierrec/lz4/v4"
@@ -119,7 +118,7 @@ func splitBaseDirs(baseDir string) []string {
 }
 
 func tryRetrieveDir(dir, gitDir, oid string, size int64, writer, errWriter *bufio.Writer) error {
-	if isRclonePath(dir) {
+	if util.IsRclonePath(dir) {
 		return retrieveFromRclone(dir, gitDir, oid, size, writer, errWriter)
 	}
 
@@ -295,15 +294,6 @@ func catRclone(remote string) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-func isRclonePath(path string) bool {
-	if runtime.GOOS == "windows" {
-		if len(path) >= 2 && path[1] == ':' {
-			return false
-		}
-	}
-	return strings.Contains(path, ":")
-}
-
 type copyCallback func(totalSize int64, readSoFar int64, readSinceLast int) error
 
 func copyFileContents(size int64, src, dst *os.File, cb copyCallback) error {
@@ -346,7 +336,7 @@ func store(baseDir string, oid string, size int64, useAction bool, a *api.Action
 
 	destPath := storagePath(baseDir, oid)
 
-	if isRclonePath(baseDir) {
+	if util.IsRclonePath(baseDir) {
 		storeToRclone(destPath, statFrom, fromPath, oid, writer, errWriter)
 		return
 	}

--- a/util/path.go
+++ b/util/path.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"runtime"
+	"strings"
+)
+
+// IsRclonePath returns true if the path refers to an rclone remote.
+// A colon (":") indicates an rclone path, except when it denotes a
+// Windows drive letter (e.g., "C:").
+func IsRclonePath(path string) bool {
+	if runtime.GOOS == "windows" {
+		if len(path) >= 2 && path[1] == ':' {
+			return false
+		}
+	}
+	return strings.Contains(path, ":")
+}


### PR DESCRIPTION
## Summary
- add util.IsRclonePath for shared rclone remote detection
- use util.IsRclonePath in root and service packages

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8b62b26548324927e3e2958b952a6