### PR TITLE
Add scripted transfer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ when you clone fresh. Here's the sequence:
 * You can provide multiple folder paths separated by semicolons in the
   configuration argument; each location will be searched in order until the
   object is found.
+* Prefix an entry with `|` to execute a shell script instead of using a
+  directory. The script is given environment variables such as `OID` and
+  `DEST` (for pulls) or `FROM` (for pushes) so you can implement custom
+  transfer behaviour and priority ordering.
 * Objects stored as `.zip` or `.lz4` files will be transparently decompressed
   on download.
 * Paths prefixed with an [rclone](https://rclone.org) alias (e.g. `remote:path`)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -585,6 +586,66 @@ func calculateFileHash(t *testing.T, filepath string) string {
 	assert.Nil(t, err)
 
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func TestRetrieveScript(t *testing.T) {
+	gitDir, err := ioutil.TempDir("", "gitdir")
+	assert.Nil(t, err)
+	defer os.RemoveAll(gitDir)
+
+	srcDir, err := ioutil.TempDir("", "src")
+	assert.Nil(t, err)
+	defer os.RemoveAll(srcDir)
+
+	srcFile := filepath.Join(srcDir, "file")
+	content := []byte("hello")
+	err = ioutil.WriteFile(srcFile, content, 0644)
+	assert.Nil(t, err)
+
+	var stdout, stderr bytes.Buffer
+	writer := bufio.NewWriter(&stdout)
+	errWriter := bufio.NewWriter(&stderr)
+
+	script := fmt.Sprintf("cp %s \"$DEST\"", srcFile)
+	oid := "123456"
+	err = tryRetrieveScript(script, gitDir, oid, int64(len(content)), writer, errWriter)
+	assert.Nil(t, err)
+
+	dest := downloadTempPath(gitDir, oid)
+	data, err := ioutil.ReadFile(dest)
+	assert.Nil(t, err)
+	assert.Equal(t, string(content), string(data))
+}
+
+func TestStoreScript(t *testing.T) {
+	remoteDir, err := ioutil.TempDir("", "remote")
+	assert.Nil(t, err)
+	defer os.RemoveAll(remoteDir)
+
+	localDir, err := ioutil.TempDir("", "local")
+	assert.Nil(t, err)
+	defer os.RemoveAll(localDir)
+
+	fromPath := filepath.Join(localDir, "file")
+	content := []byte("world")
+	err = ioutil.WriteFile(fromPath, content, 0644)
+	assert.Nil(t, err)
+	stat, err := os.Stat(fromPath)
+	assert.Nil(t, err)
+
+	var stdout, stderr bytes.Buffer
+	writer := bufio.NewWriter(&stdout)
+	errWriter := bufio.NewWriter(&stderr)
+
+	oid := "abcdef"
+	script := fmt.Sprintf("cp \"$FROM\" %s/$OID", remoteDir)
+	err = storeUsingScript(script, oid, stat, fromPath, writer, errWriter)
+	assert.Nil(t, err)
+
+	dest := filepath.Join(remoteDir, oid)
+	data, err := ioutil.ReadFile(dest)
+	assert.Nil(t, err)
+	assert.Equal(t, string(content), string(data))
 }
 
 func completionPaths(t *testing.T, stdout string) map[string]string {


### PR DESCRIPTION
## Summary
- allow base directories prefixed with `|` to run custom scripts for pull/push
- add helper to execute scripts and expose environment variables
- document scripted transfers and add tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8b95a056c8324864c0774dd522dd1