### PR TITLE
Handle large request lines in service scanner

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -25,6 +25,9 @@ import (
 func Serve(pullBaseDir, pushBaseDir string, usePullAction, usePushAction bool, stdin io.Reader, stdout, stderr io.Writer) {
 
 	scanner := bufio.NewScanner(stdin)
+	// Allow requests larger than the default 64 KB limit by raising the
+	// maximum token size to 1 MB.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	writer := bufio.NewWriter(stdout)
 	errWriter := bufio.NewWriter(stderr)
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -662,6 +662,18 @@ func completionPaths(t *testing.T, stdout string) map[string]string {
 	return paths
 }
 
+func TestServeHandlesLargeRequests(t *testing.T) {
+	padding := strings.Repeat("a", 70*1024)
+	req := fmt.Sprintf("{\"event\":\"terminate\",\"padding\":\"%s\"}\n", padding)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	Serve("", "", false, false, strings.NewReader(req), &stdout, &stderr)
+
+	assert.Contains(t, stderr.String(), "Terminating test custom adapter gracefully.")
+}
+
 func createZipFromFile(src, dest string) error {
 	in, err := os.Open(src)
 	if err != nil {


### PR DESCRIPTION
## Summary
- increase bufio.Scanner token limit to 1MB to accept large JSON requests
- add regression test ensuring oversized request lines are processed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8bb2aab4c8324bcf5b7eaa3278a72