### PR TITLE
Fix build errors in service package

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -611,7 +611,8 @@ func TestRetrieveScript(t *testing.T) {
 	err = tryRetrieveScript(script, gitDir, oid, int64(len(content)), writer, errWriter)
 	assert.Nil(t, err)
 
-	dest := downloadTempPath(gitDir, oid)
+	dest, err := downloadTempPath(gitDir, oid)
+	assert.Nil(t, err)
 	data, err := ioutil.ReadFile(dest)
 	assert.Nil(t, err)
 	assert.Equal(t, string(content), string(data))


### PR DESCRIPTION
## Summary
- handle downloadTempPath error in script retrieval
- clean up store logic and use util.IsRclonePath
- add runtime import and update tests

## Testing
- `go test ./...`
- `go build ./...`
- `go build -o lfs-folderstore.exe`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0f46be8832485808f5c4e4137f2