### PR TITLE
chore: rename binary to elastic-git-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ with 2.5.2 and 2.6.0 (and with Git 2.19.1).
 
 ### Download &amp; install
 
-You will need `lfs-folderstore[.exe]` to be on your system path somewhere.
+You will need `elastic-git-storage[.exe]` to be on your system path somewhere.
 
 Either download and extract the [latest
-release](https://github.com/sinbad/lfs-folderstore/releases), or build it from
+release](https://github.com/sinbad/elastic-git-storage/releases), or build it from
 source using the standard `go build`.
 
 ### Configure a fresh repo
@@ -56,7 +56,7 @@ Starting a new repository is the easiest case.
 * Create some commits with LFS binaries
 * Add your plain git remote using `git remote add origin <url>`
 * Run these commands to configure your LFS folder:
-  * `git config --add lfs.customtransfer.lfs-folder.path lfs-folderstore`
+  * `git config --add lfs.customtransfer.lfs-folder.path elastic-git-storage`
   * `git config --add lfs.customtransfer.lfs-folder.args "C:/path/to/your/folder"`
   * `git config --add lfs.standalonetransferagent lfs-folder`
 * `git push origin master` will now copy any media to that folder
@@ -77,7 +77,7 @@ you want to either move to a folder, or replicate, it's a little more complicate
 
 * Create a new remote using `git remote add folderremote <url>`. Do this even if you want to keep the git repo at the same URL as currently.
 * Run these commands to configure the folder store:
-  * `git config --add lfs.customtransfer.lfs-folder.path lfs-folderstore`
+  * `git config --add lfs.customtransfer.lfs-folder.path elastic-git-storage`
   * `git config --add lfs.customtransfer.lfs-folder.args "C:/path/to/your/folder"`
   * `git config --add lfs.<url>.standalonetransferagent lfs-folder` - important: use the new Git repo URL
 * `git push folderremote master ...` - important: list all branches you wish to keep LFS content for. Only LFS content which is reachable from the branches you list (at any version) will be copied to the remote
@@ -96,7 +96,7 @@ when you clone fresh. Here's the sequence:
     * this will work for the git data, but will report "Error downloading object" when trying to get LFS data
 * `cd <folder>` - to enter your newly cloned repo
 * Configure as with a new repo:
-  * `git config --add lfs.customtransfer.lfs-folder.path lfs-folderstore`
+  * `git config --add lfs.customtransfer.lfs-folder.path elastic-git-storage`
   * `git config --add lfs.customtransfer.lfs-folder.args "C:/path/to/your/folder"`
   * `git config --add lfs.standalonetransferagent lfs-folder`
 * `git reset --hard master`

--- a/build.ps1
+++ b/build.ps1
@@ -28,7 +28,7 @@ function Zip-Release {
 }
 
 $package = "github.com/sinbad/lfs-folderstore"
-$archivename = "lfs-folderstore"
+$archivename = "elastic-git-storage"
 
 # Check dirty repo
 git diff --no-patch --exit-code
@@ -68,7 +68,7 @@ foreach ($BuildOS in $BuildConfigs.GetEnumerator()) {
 
         $env:GOOS=$($BuildOS.Name)
         $env:GOARCH=$Arch 
-        go build -ldflags "-X $package/cmd.Version=$Version" $package
+        go build -ldflags "-X $package/cmd.Version=$Version" -o elastic-git-storage $package
 
         Pop-Location
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,9 +54,9 @@ func Execute() {
 
 func init() {
 	RootCmd = &cobra.Command{
-		Use:   "lfs-folderstore",
+		Use:   "elastic-git-storage",
 		Short: "git-lfs custom transfer adapter to store all data in a folder",
-		Long: `lfs-folderstore treats a simple folder, probably a shared one,
+		Long: `elastic-git-storage treats a simple folder, probably a shared one,
 		as the remote store for all LFS object data. Upload and download functions
 		are turned into simple file copies to destinations determined by the id
 		of the object.`,
@@ -76,7 +76,7 @@ func init() {
 func usageCommand(cmd *cobra.Command) error {
 	usage := `
 Usage:
-  lfs-folderstore [options] <basedir>
+  elastic-git-storage [options] <basedir>
 
 Arguments:
   basedir      Base directory for the object store (required)
@@ -101,7 +101,7 @@ Note:
 func rootCommand(cmd *cobra.Command, args []string) {
 
 	if printVersion {
-		os.Stderr.WriteString(fmt.Sprintf("lfs-folder %v\n", Version))
+		os.Stderr.WriteString(fmt.Sprintf("elastic-git-storage %v\n", Version))
 		os.Exit(0)
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -58,7 +58,7 @@ func Serve(pullBaseDir, pushBaseDir string, usePullAction, usePushAction bool, s
 			if len(pullBaseDir) == 0 {
 				resp.Error = &api.TransferError{Code: 9, Message: "Base directory not specified, check config"}
 			} else {
-				util.WriteToStderr(fmt.Sprintf("Initialised lfs-folderstore custom adapter for %s\n", req.Operation), errWriter)
+				util.WriteToStderr(fmt.Sprintf("Initialised elastic-git-storage custom adapter for %s\n", req.Operation), errWriter)
 			}
 			api.SendResponse(resp, writer, errWriter)
 		case "download":
@@ -627,7 +627,7 @@ func storeToRclone(destPath, compression string, statFrom os.FileInfo, fromPath,
 	var tmp *os.File
 	var err error
 	if compression == "zip" || compression == "lz4" {
-		tmp, err = os.CreateTemp("", "lfs-folderstore")
+		tmp, err = os.CreateTemp("", "elastic-git-storage")
 		if err != nil {
 			return false, err
 		}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -238,7 +238,7 @@ func TestUploadRclone(t *testing.T) {
 	defer os.RemoveAll(setup.localpath)
 	defer os.RemoveAll(setup.remotepath)
 
-	scriptDir, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-rclone")
+	scriptDir, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-rclone")
 	assert.Nil(t, err)
 	defer os.RemoveAll(scriptDir)
 
@@ -287,10 +287,10 @@ type testSetup struct {
 
 func setupUploadTest(t *testing.T) *testSetup {
 	// Create 2 temporary dirs, pretending to be git repo and dest shared folder
-	gitpath, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-test-local")
+	gitpath, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-test-local")
 	assert.Nil(t, err, "Error creating temp git path")
 
-	storepath, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-test-remote")
+	storepath, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-test-remote")
 	assert.Nil(t, err, "Error creating temp shared path")
 
 	testfiles := []testFile{
@@ -412,7 +412,7 @@ func TestDownloadFallback(t *testing.T) {
 	defer os.RemoveAll(setup.localpath)
 	defer os.RemoveAll(setup.remotepath)
 
-	emptyDir, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-empty")
+	emptyDir, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-empty")
 	assert.Nil(t, err)
 	defer os.RemoveAll(emptyDir)
 
@@ -447,7 +447,7 @@ func TestDownloadZip(t *testing.T) {
 		setup.files[i].path = zipPath
 	}
 
-	emptyDir, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-empty")
+	emptyDir, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-empty")
 	assert.Nil(t, err)
 	defer os.RemoveAll(emptyDir)
 
@@ -481,7 +481,7 @@ func TestDownloadLz4(t *testing.T) {
 		setup.files[i].path = lz4Path
 	}
 
-	emptyDir, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-empty")
+	emptyDir, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-empty")
 	assert.Nil(t, err)
 	defer os.RemoveAll(emptyDir)
 
@@ -508,7 +508,7 @@ func TestDownloadRclone(t *testing.T) {
 	defer os.RemoveAll(setup.localpath)
 	defer os.RemoveAll(setup.remotepath)
 
-	scriptDir, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-rclone")
+	scriptDir, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-rclone")
 	assert.Nil(t, err)
 	defer os.RemoveAll(scriptDir)
 
@@ -564,10 +564,10 @@ func finishDownload(buf *bytes.Buffer) {
 
 func setupDownloadTest(t *testing.T) *testSetup {
 	// Create 2 temporary dirs, pretending to be git repo and dest shared folder
-	gitpath, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-test-local")
+	gitpath, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-test-local")
 	assert.Nil(t, err, "Error creating temp git path")
 
-	storepath, err := ioutil.TempDir(os.TempDir(), "lfs-folderstore-test-remote")
+	storepath, err := ioutil.TempDir(os.TempDir(), "elastic-git-storage-test-remote")
 	assert.Nil(t, err, "Error creating temp shared path")
 
 	testfiles := []testFile{


### PR DESCRIPTION
## Summary
- rename CLI binary and usage to elastic-git-storage
- update build script and docs for new executable name
- adjust service logging and tests for new name

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bce029e1508324a9ef9e067632f744